### PR TITLE
Restock Compatibility

### DIFF
--- a/files/PorkjetParts/Engine/liquidEngineLV-909.cfg
+++ b/files/PorkjetParts/Engine/liquidEngineLV-909.cfg
@@ -7,7 +7,7 @@
 // in it. If you're running KSP 1.6, the new stock Terrier will automatically
 // and silently replace this reskinned version.
 
-@PART[liquidEngine3]
+@PART[liquidEngine3]:NEEDS[!ReStock]
 {
 	@author = Porkjet
 	MODEL

--- a/files/PorkjetParts/Engine/liquidEngineLV-T30.cfg
+++ b/files/PorkjetParts/Engine/liquidEngineLV-T30.cfg
@@ -1,6 +1,6 @@
 // Reskin the Reliant engine with Porkjet's overhauled model.
 
-@PART[liquidEngine]
+@PART[liquidEngine]:NEEDS[!ReStock]
 {
 	@author = Porkjet
 	MODEL

--- a/files/PorkjetParts/Engine/liquidEngineLV-T45.cfg
+++ b/files/PorkjetParts/Engine/liquidEngineLV-T45.cfg
@@ -1,6 +1,6 @@
 // Reskin the Swivel engine with Porkjet's overhauled model.
 
-@PART[liquidEngine2]
+@PART[liquidEngine2]:NEEDS[!ReStock]
 {
 	@author = Porkjet
 	MODEL

--- a/files/PorkjetParts/FuelTank/fuelTankT100.cfg
+++ b/files/PorkjetParts/FuelTank/fuelTankT100.cfg
@@ -1,7 +1,7 @@
 // Reskin the FL-T100 tank with Porkjet's overhauled model.
 // Include a gray/orange variant texture, kindly provided by Jarin.
 
-@PART[fuelTankSmallFlat]
+@PART[fuelTankSmallFlat]:NEEDS[!ReStock]
 {
 	@author = Porkjet
 	%rescaleFactor = 1.0

--- a/files/PorkjetParts/FuelTank/fuelTankT200.cfg
+++ b/files/PorkjetParts/FuelTank/fuelTankT200.cfg
@@ -1,7 +1,7 @@
 // Reskin the FL-T200 tank with Porkjet's overhauled model.
 // Include a gray/orange variant texture, kindly provided by Jarin.
 
-@PART[fuelTankSmall]
+@PART[fuelTankSmall]:NEEDS[!ReStock]
 {
 	@author = Porkjet
 	@scale = 1

--- a/files/PorkjetParts/FuelTank/fuelTankT400.cfg
+++ b/files/PorkjetParts/FuelTank/fuelTankT400.cfg
@@ -1,7 +1,7 @@
 // Reskin the FL-T400 tank with Porkjet's overhauled model.
 // Include a gray/orange variant texture, kindly provided by Jarin.
 
-@PART[fuelTank]
+@PART[fuelTank]:NEEDS[!ReStock]
 {
 	@author = Porkjet
 	@scale = 1

--- a/files/PorkjetParts/FuelTank/fuelTankT800.cfg
+++ b/files/PorkjetParts/FuelTank/fuelTankT800.cfg
@@ -1,7 +1,7 @@
 // Reskin the FL-T800 tank with Porkjet's overhauled model.
 // Include a gray/orange variant texture, kindly provided by Jarin.
 
-@PART[fuelTank_long]
+@PART[fuelTank_long]:NEEDS[!ReStock]
 {
 	@author = Porkjet
 	@scale = 1

--- a/files/rescaled/Size3LargeTank.cfg
+++ b/files/rescaled/Size3LargeTank.cfg
@@ -1,5 +1,5 @@
 // Update the Kerbodyne S3-14400 tank to have a gray-orange variant.
-@PART[Size3LargeTank]:NEEDS[SquadExpansion/MakingHistory] {
+@PART[Size3LargeTank]:NEEDS[SquadExpansion/MakingHistory,!ReStock] {
 	// Add the model for the FL-TX1800 tank, rescaled, for its gray/orange texture.
 	MODEL
 	{

--- a/files/rescaled/Size3MediumTank.cfg
+++ b/files/rescaled/Size3MediumTank.cfg
@@ -1,5 +1,5 @@
 // Update the Kerbodyne S3-7200 tank to have a gray-orange variant.
-@PART[Size3MediumTank]:NEEDS[SquadExpansion/MakingHistory] {
+@PART[Size3MediumTank]:NEEDS[SquadExpansion/MakingHistory,!ReStock] {
 	// Add the model for the FL-TX900 tank, rescaled, for its gray/orange texture.
 	MODEL
 	{

--- a/files/rescaled/Size3SmallTank.cfg
+++ b/files/rescaled/Size3SmallTank.cfg
@@ -1,5 +1,5 @@
 // Update the Kerbodyne S3-3600 tank to have a gray-orange variant.
-@PART[Size3SmallTank]:NEEDS[SquadExpansion/MakingHistory] {
+@PART[Size3SmallTank]:NEEDS[SquadExpansion/MakingHistory,!ReStock] {
 	// Add the model for the FL-TX440 tank, rescaled, for its gray/orange texture.
 	MODEL
 	{


### PR DESCRIPTION
The patches in MissingHistory that replace the models of the LV-T45, LV-T30 and LV-909 cause conflicts with ReStock, as they make modifications to attach nodes and other items beyond models. This PR adds a `:NEEDS[!ReStock]` flag to these patches so they won't conflict when both mods are installed