### PR TITLE
Added offset for the iva

### DIFF
--- a/files/parts/PaliciPod.cfg
+++ b/files/parts/PaliciPod.cfg
@@ -176,6 +176,7 @@ PART
 	INTERNAL
 	{
 		name = MK2POD_IVA
+		offset = 0, 0, -0.3 
 	}
 }
 


### PR DESCRIPTION
IVA was  too far back, I've added an offset so that it will be visible properly.  This was causing problems both on the flight scene, where the portraits are shown, as well is when showing the see-through of the vessel